### PR TITLE
Fallen Empire Duplicate Ethics Prevention

### DIFF
--- a/common/fallen_empires/SOLL_fallen_empires.txt
+++ b/common/fallen_empires/SOLL_fallen_empires.txt
@@ -6,6 +6,16 @@ fallen_empire_of_gloom = {
 
 	weight_modifier = {
 		base = 100
+		modifier = {
+			factor = 0
+			modifier = {
+				factor = 99999
+				has_origin = origin_scion
+			}
+			any_country = {
+				has_country_flag = fallen_empire_1
+			}
+		}
 	}
 
 	create_country_effect = {

--- a/common/fallen_empires/SOLL_fallen_empires.txt
+++ b/common/fallen_empires/SOLL_fallen_empires.txt
@@ -8,13 +8,13 @@ fallen_empire_of_gloom = {
 		base = 100
 		modifier = {
 			factor = 0
-			modifier = {
-				factor = 99999
-				has_origin = origin_scion
-			}
 			any_country = {
 				has_country_flag = fallen_empire_1
 			}
+		}
+		modifier = {
+			factor = 99999
+			has_origin = origin_scion
 		}
 	}
 
@@ -127,6 +127,12 @@ fallen_rudonian_peoples_republic = {
 
 	weight_modifier = {
 		base = 100
+		modifier = {
+			factor = 0
+			any_country = {
+				has_country_flag = fallen_empire_3
+			}
+		}
 	}
 
 	create_country_effect = {
@@ -238,6 +244,12 @@ fallen_the_hugbox_neighborhood = {
 
 	weight_modifier = {
 		base = 100
+		modifier = {
+			factor = 0
+			any_country = {
+				has_country_flag = fallen_machine_empire_1
+			}
+		}
 	}
 
 	possible = {
@@ -352,6 +364,12 @@ fallen_empire_lenkashayt_acquisitive_venture = {
 
 	weight_modifier = {
 		base = 100
+		modifier = {
+			factor = 0
+			any_country = {
+				has_country_flag = fallen_empire_3
+			}
+		}
 	}
 
 	create_country_effect = {
@@ -464,6 +482,12 @@ fallen_empire_leaders_of_the_free_world = {
 
 	weight_modifier = {
 		base = 100
+		modifier = {
+			factor = 0
+			any_country = {
+				has_country_flag = fallen_empire_3
+			}
+		}
 	}
 
 	create_country_effect = {
@@ -574,6 +598,12 @@ fallen_empire_radishing_vassal_factory = {
 
 	weight_modifier = {
 		base = 100
+		modifier = {
+			factor = 0
+			any_country = {
+				has_country_flag = fallen_empire_4
+			}
+		}
 	}
 
 	create_country_effect = {
@@ -686,6 +716,12 @@ fallen_empire_of_the_glirr = {
 
 	weight_modifier = {
 		base = 100
+		modifier = {
+			factor = 0
+			any_country = {
+				has_country_flag = fallen_empire_4
+			}
+		}
 	}
 
 	create_country_effect = {
@@ -805,6 +841,12 @@ fallen_mircorv_coalescence = {
 
 	weight_modifier = {
 		base = 600
+		modifier = {
+			factor = 0
+			any_country = {
+				has_country_flag = fallen_machine_empire
+			}
+		}
 	}
 
 	possible = {
@@ -914,6 +956,12 @@ fallen_empire_united_earth = {
 
 	weight_modifier = {
 		base = 100
+		modifier = {
+			factor = 0
+			any_country = {
+				has_country_flag = fallen_empire_4
+			}
+		}
 	}
 
 	create_country_effect = {
@@ -1026,6 +1074,12 @@ fallen_empire_moragi = {
 
 	weight_modifier = {
 		base = 100
+		modifier = {
+			factor = 0
+			any_country = {
+				has_country_flag = fallen_empire_3
+			}
+		}
 	}
 
 	create_country_effect = {
@@ -1139,6 +1193,12 @@ fallen_empire_lilliput = {
 
 	weight_modifier = {
 		base = 100
+		modifier = {
+			factor = 0
+			any_country = {
+				has_country_flag = fallen_empire_2
+			}
+		}
 		modifier = {
 			factor = 99999
 			has_origin = origin_scion
@@ -1255,6 +1315,12 @@ fallen_empire_coaltion_of_equals = {
 
 	weight_modifier = {
 		base = 100
+		modifier = {
+			factor = 0
+			any_country = {
+				has_country_flag = fallen_empire_1
+			}
+		}
 		modifier = {
 			factor = 99999
 			has_origin = origin_scion
@@ -1377,6 +1443,12 @@ fallen_machine_empire_pornhub = {
 
 	weight_modifier = {
 		base = 100
+		modifier = {
+			factor = 0
+			any_country = {
+				has_country_flag = fallen_empire_machine
+			}
+		}
 	}
 
 	possible = {
@@ -1495,6 +1567,12 @@ fallen_empire_syndicate = {
 	weight_modifier = {
 		base = 100
 		modifier = {
+			factor = 0
+			any_country = {
+				has_country_flag = fallen_empire_2
+			}
+		}
+		modifier = {
 			factor = 99999
 			has_origin = origin_scion
 		}
@@ -1611,6 +1689,12 @@ fallen_machine_empire_kubik = {
 
 	weight_modifier = {
 		base = 100
+		modifier = {
+			factor = 0
+			any_country = {
+				has_country_flag = fallen_empire_machine
+			}
+		}
 	}
 
 	possible = {
@@ -1731,6 +1815,12 @@ fallen_machine_empire_welders = {
 
 	weight_modifier = {
 		base = 100
+		modifier = {
+			factor = 0
+			any_country = {
+				has_country_flag = fallen_empire_machine
+			}
+		}
 	}
 
 	possible = {
@@ -1850,6 +1940,12 @@ fallen_machine_empire_zaibatsu = {
 
 	weight_modifier = {
 		base = 100
+		modifier = {
+			factor = 0
+			any_country = {
+				has_country_flag = fallen_empire_machine
+			}
+		}
 	}
 
 	possible = {


### PR DESCRIPTION
Ensures the weight of a fallen empire is 0 when another fallen empire of the same ethics has spawned.